### PR TITLE
ТЗ спринта № 12 ver. 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 - **Minikube**
 - **Jenkins** (plugin Blue Ocean)
 - **Kafka**
+- **Zipkin**
+- **Prometheus**
+- **Grafana**
+- **Elastic**
+- **Logstash**
+- **Kibana**
 
 ## Запуск приложения с использованием Jenkins и K8s
 

--- a/accounts/pom.xml
+++ b/accounts/pom.xml
@@ -112,6 +112,35 @@
 			<artifactId>spring-boot-testcontainers</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.24.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/accounts/src/main/resources/application.yaml
+++ b/accounts/src/main/resources/application.yaml
@@ -54,3 +54,14 @@ feign:
 kafka:
   bootstrap:
     servers: localhost:9092
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  zipkin:
+    tracing:
+      endpoint:  http://127.0.0.1:9411/api/v2/spans
+  tracing:
+    sampling:
+      probability: 1

--- a/accounts/src/main/resources/log4j2.xml
+++ b/accounts/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+        </Console>
+        <Kafka name="Kafka" topic="coffee-logs">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+            <Property name="bootstrap.servers">localhost:9092</Property>
+        </Kafka>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Kafka"/>
+        </Root>
+        <Logger name="org.apache.kafka" level="INFO" >
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/blocker/pom.xml
+++ b/blocker/pom.xml
@@ -56,6 +56,35 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.24.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/blocker/src/main/resources/application.yaml
+++ b/blocker/src/main/resources/application.yaml
@@ -20,3 +20,14 @@ spring:
             clientAuthenticationMethod: client_secret_post
 server:
   port: 8082
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  zipkin:
+    tracing:
+      endpoint:  http://127.0.0.1:9411/api/v2/spans
+  tracing:
+    sampling:
+      probability: 1

--- a/blocker/src/main/resources/log4j2.xml
+++ b/blocker/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+        </Console>
+        <Kafka name="Kafka" topic="coffee-logs">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+            <Property name="bootstrap.servers">localhost:9092</Property>
+        </Kafka>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Kafka"/>
+        </Root>
+        <Logger name="org.apache.kafka" level="INFO" >
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/cash/pom.xml
+++ b/cash/pom.xml
@@ -60,6 +60,35 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.24.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/cash/src/main/resources/application.yaml
+++ b/cash/src/main/resources/application.yaml
@@ -23,3 +23,14 @@ server:
 feign:
   accounts: http://localhost:8081
   blocker: http://localhost:8082
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  zipkin:
+    tracing:
+      endpoint:  http://127.0.0.1:9411/api/v2/spans
+  tracing:
+    sampling:
+      probability: 1

--- a/cash/src/main/resources/log4j2.xml
+++ b/cash/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+        </Console>
+        <Kafka name="Kafka" topic="coffee-logs">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+            <Property name="bootstrap.servers">localhost:9092</Property>
+        </Kafka>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Kafka"/>
+        </Root>
+        <Logger name="org.apache.kafka" level="INFO" >
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/exchange-generator/pom.xml
+++ b/exchange-generator/pom.xml
@@ -69,6 +69,35 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.24.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/exchange-generator/src/main/resources/application.yaml
+++ b/exchange-generator/src/main/resources/application.yaml
@@ -25,3 +25,14 @@ feign:
 kafka:
   bootstrap:
     servers: localhost:9092
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  zipkin:
+    tracing:
+      endpoint:  http://127.0.0.1:9411/api/v2/spans
+  tracing:
+    sampling:
+      probability: 1

--- a/exchange-generator/src/main/resources/log4j2.xml
+++ b/exchange-generator/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+        </Console>
+        <Kafka name="Kafka" topic="coffee-logs">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+            <Property name="bootstrap.servers">localhost:9092</Property>
+        </Kafka>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Kafka"/>
+        </Root>
+        <Logger name="org.apache.kafka" level="INFO" >
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/exchange/pom.xml
+++ b/exchange/pom.xml
@@ -110,6 +110,35 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.24.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/exchange/src/main/resources/application.yaml
+++ b/exchange/src/main/resources/application.yaml
@@ -51,6 +51,17 @@ spring:
 kafka:
   bootstrap:
     servers: localhost:9092
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  zipkin:
+    tracing:
+      endpoint:  http://127.0.0.1:9411/api/v2/spans
+  tracing:
+    sampling:
+      probability: 1
 exchange:
   rate-ranges:
     USD:

--- a/exchange/src/main/resources/log4j2.xml
+++ b/exchange/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+        </Console>
+        <Kafka name="Kafka" topic="coffee-logs">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+            <Property name="bootstrap.servers">localhost:9092</Property>
+        </Kafka>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Kafka"/>
+        </Root>
+        <Logger name="org.apache.kafka" level="INFO" >
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/exchange/src/test/java/com/bankapp/exchange/ExchangeApplicationTests.java
+++ b/exchange/src/test/java/com/bankapp/exchange/ExchangeApplicationTests.java
@@ -27,12 +27,12 @@ class ExchangeApplicationTests extends SpringBootPostgreSQLTestContainerBaseTest
 	private RateService rateService;
 
 	@Test
-	@Order(1)
+	@Order(2)
 	void contextLoads() {
 	}
 
 	@Test
-	@Order(2)
+	@Order(1)
 	void kafkaTest() throws JsonProcessingException, ExecutionException, InterruptedException {
 		UpdateRandomCurrencyDto dto = new UpdateRandomCurrencyDto();
 		dto.setValue(1);

--- a/front/pom.xml
+++ b/front/pom.xml
@@ -60,6 +60,39 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.24.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.openfeign</groupId>
+			<artifactId>feign-micrometer</artifactId>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/front/src/main/resources/application.yaml
+++ b/front/src/main/resources/application.yaml
@@ -23,3 +23,14 @@ feign:
   cash: http://localhost:8083
   transfer: http://localhost:8087
   notifications: http://localhost:8086
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  zipkin:
+    tracing:
+      endpoint:  http://127.0.0.1:9411/api/v2/spans
+  tracing:
+    sampling:
+      probability: 1

--- a/front/src/main/resources/log4j2.xml
+++ b/front/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+        </Console>
+        <Kafka name="Kafka" topic="coffee-logs">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+            <Property name="bootstrap.servers">localhost:9092</Property>
+        </Kafka>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Kafka"/>
+        </Root>
+        <Logger name="org.apache.kafka" level="INFO" >
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -41,3 +41,27 @@ dependencies:
     version: "19.3.3"  # Use a known stable version from Bitnami (check their version history)
     repository: "https://charts.bitnami.com/bitnami"
     alias: app-kafka
+  - name: zipkin
+    version: "0.5.0"
+    repository: "https://charts.bitnami.com/bitnami"
+    alias: app-zipkin
+  - name: prometheus
+    version: "18.1.1"
+    repository: "https://charts.bitnami.com/bitnami"
+    alias: app-prometheus
+  - name: grafana
+    version: "8.2.0"
+    repository: "https://charts.bitnami.com/bitnami"
+    alias: app-grafana
+  - name: elasticsearch
+    version: "20.1.2"
+    repository: "https://charts.bitnami.com/bitnami"
+    alias: app-elastic
+  - name: logstash
+    version: "6.2.0"
+    repository: "https://charts.bitnami.com/bitnami"
+    alias: app-logstash
+  - name: kibana
+    version: "12.1.0"
+    repository: "https://charts.bitnami.com/bitnami"
+    alias: app-kibana

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -108,6 +108,35 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.24.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/notifications/src/main/resources/application.yaml
+++ b/notifications/src/main/resources/application.yaml
@@ -51,3 +51,14 @@ spring:
 kafka:
   bootstrap:
     servers: localhost:9092
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  zipkin:
+    tracing:
+      endpoint:  http://127.0.0.1:9411/api/v2/spans
+  tracing:
+    sampling:
+      probability: 1

--- a/notifications/src/main/resources/log4j2.xml
+++ b/notifications/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+        </Console>
+        <Kafka name="Kafka" topic="coffee-logs">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+            <Property name="bootstrap.servers">localhost:9092</Property>
+        </Kafka>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Kafka"/>
+        </Root>
+        <Logger name="org.apache.kafka" level="INFO" >
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/transfer/pom.xml
+++ b/transfer/pom.xml
@@ -63,6 +63,35 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.24.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/transfer/src/main/resources/application.yaml
+++ b/transfer/src/main/resources/application.yaml
@@ -24,3 +24,14 @@ feign:
   accounts: http://localhost:8081
   exchange: http://localhost:8084
   blocker: http://localhost:8082
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  zipkin:
+    tracing:
+      endpoint:  http://127.0.0.1:9411/api/v2/spans
+  tracing:
+    sampling:
+      probability: 1

--- a/transfer/src/main/resources/log4j2.xml
+++ b/transfer/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+        </Console>
+        <Kafka name="Kafka" topic="coffee-logs">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level: %msg%n"/>
+            <Property name="bootstrap.servers">localhost:9092</Property>
+        </Kafka>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Kafka"/>
+        </Root>
+        <Logger name="org.apache.kafka" level="INFO" >
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Привести в соответствие с ТЗ спринта № 12.
С учётом замечаний (по предыдущему спринту № 11):
- вынести Kafka-слушатель из `RateService` в `ExchangeKafkaListener`;
- заменить `new ObjectMapper()` на инъекцию `ObjectMapper` в `ExchangeKafkaListener` и `NotificationService`;
- добавить абстракцию `MessageProducer` и реализацию `KafkaMessageProducer`;
- заменить в `NotificationService` `System.out` в DLT-обработчике на лог SLF4J;
- уточнить обработку ошибок в `NotificationService`;
- заменить в тесте `ExchangeApplicationTests` `Thread.sleep` на Awaitility;
- добавить Spotless в корневой `pom.xml` для сортировки импортов;
- вынести в `accounts` имя топика.